### PR TITLE
Setup CI via GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  prebuilds:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+          - os: macos-latest
+            arch: x64
+          - os: windows-latest
+            arch: x86
+          - os: windows-latest
+            arch: x64
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.os }} ${{ matrix.arch }}
+    env:
+      NODE_VERSION: 16
+      VERSION_NAME: ${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Set up node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          node-version: ${{ env.NODE_VERSION }}
+          architecture: ${{ matrix.arch }}
+      - name: Install dependencies
+        shell: bash
+        run: npm install --build-from-source
+      - name: Prebuild ${{ env.VERSION_NAME }}
+        shell: bash
+        run: npm run prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false
+      - name: Create artifact
+        shell: bash
+        run: |
+          tar -zcvf $ARCHIVE_NAME -C prebuilds .
+          stat "$ARCHIVE_NAME"
+        env:
+          ARCHIVE_NAME: ${{ env.VERSION_NAME }}.tar.gz
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.VERSION_NAME }}
+          path: ${{ env.VERSION_NAME }}.tar.gz
+          retention-days: 1
+
+  release_and_publish:
+    runs-on: ubuntu-latest
+    needs: prebuilds
+    permissions:
+      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Set up node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - name: Build the docs
+        run: npm run docs
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: prebuilds
+      - name: Create ${{ github.ref }} release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: prebuilds/*/*.tar.gz
+        env:
+          ARCHIVE_NAME: ${{ github.ref_name }}-${{ runner.os }}-${{ runner.arch }}.tar
+      - run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
+      fail-fast: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies and test
+        shell: bash
+        run: |
+          npm install --build-from-source
+          npm test
+      - name: Test build
+        shell: bash
+        run: npm run prebuild

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ build
 node-addon-api
 
 prebuilds/
+
+docs/index.html

--- a/docs/compile.js
+++ b/docs/compile.js
@@ -5,7 +5,7 @@
 
 var fs = require('fs')
 var dox = require('dox')
-var jade = require('jade')
+var jade = require('pug')
 var marked = require('marked')
 var hljs = require('highlight.js')
 var assert = require('assert')
@@ -146,8 +146,8 @@ function markdown (code) {
  */
 
 function highlight (code, lang) {
-  if (!hljs.LANGUAGES.hasOwnProperty(lang)) {
+  if (!hljs.listLanguages().hasOwnProperty(lang)) {
     lang = 'javascript'
   }
-  return hljs.highlight(lang, code).value
+  return hljs.highlight(code, { language: lang }).value
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "64",
     "napi"
   ],
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "author": "Anna Henningsen <anna@addaleax.net>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ref-napi",
+  "name": "@alphacep/ref-napi",
   "description": "Turn Buffer instances into \"pointers\"",
   "engines": {
     "node": ">= 10.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "nyc mocha --expose-gc",
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi --tag-armv",
-    "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))"
+    "prepack": "npm run prebuild && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))"
   },
   "dependencies": {
     "debug": "^4.3.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "prepack": "npm run prebuild && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))"
   },
   "dependencies": {
-    "debug": "^4.3.1"
+    "debug": "^4.3.1",
+    "node-gyp-build": "^4.2.1"
   },
   "devDependencies": {
     "dox": "0.9.0",
@@ -46,7 +47,6 @@
     "marked": "^1.0.0",
     "mocha": "^8.4.0",
     "node-addon-api": "^3.0.0",
-    "node-gyp-build": "^4.2.1",
     "nyc": "^15.0.0",
     "prebuildify": "^4.1.2",
     "prebuildify-ci": "^1.0.5",


### PR DESCRIPTION
This essentially setup CI/CD as Github actions.

I took some inspirations from https://github.com/Level/leveldown/blob/master/.github/workflows/release.yml to automate the prebuilds.

The `test.yml` workflow test on a variety of platform and node version. 
See for example:
https://github.com/larriereguichet/alphacep-ref-napi/actions/runs/1530682216

The `release.yml` workflow create the prebuilds artefact create a Github release and publish the package to npm.
See an example of release:
https://github.com/larriereguichet/alphacep-ref-napi/releases/tag/3.0.3

As for the next steps I would recommend to:
1. Create an `alphacep` organisation on npm (if not already): 
https://www.npmjs.com/org/create
2. Generate a *publish* npm access token: 
https://www.npmjs.com/settings/nshmyrev/tokens
3. Add it as `NPM_TOKEN` to the repository secrets:
https://github.com/alphacep/ref-napi/settings/secrets/actions
3. ~~Bump version number in `package.json` and~~ push a new tag to publish the new release:
```
git tag -f 4.0.1
git push origin --tags
```

Hope it helps,
Cheers!